### PR TITLE
Adição de predicados e fatos

### DIFF
--- a/hospital.als
+++ b/hospital.als
@@ -13,6 +13,24 @@ fact relacaoFuncionarioPaciente{
 	all f: Funcionario | #f.paciente < 6 
 }
 
+fact atendimentoPacienteCirurgiado{
+	all p:PacienteCirurgiado  | funcionariosDoPacienteCirurgiado[p]
+}
+
+fact atendimentoPacienteNaoCirurgiado{
+	all p:PacienteNaoCirurgiado  | funcionariosDoPacienteNaoCirurgiado[p]
+}
+
+pred funcionariosDoPacienteCirurgiado[p: PacienteCirurgiado]{
+	one getMedicosPacienteCirurgiado[p]
+	#(getEnfermeiroPacienteCirurgiado [p])=2
+}
+
+pred funcionariosDoPacienteNaoCirurgiado[p: PacienteNaoCirurgiado]{
+	no getMedicosPacienteNaoCirurgiado[p]
+	one getEnfermeiroPacienteNaoCirurgiado[p]
+}
+
 fun getMedicosPacienteCirurgiado [p: PacienteCirurgiado] : set Medico {
     Medico & p.~paciente
 }


### PR DESCRIPTION
Adição de predicados e fatos que definem a quantidade de médicos e enfermeiros que pacientes cirurgiados e não-cirurgiados devem possuir.